### PR TITLE
Launch pulseaudio with better options

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -19,4 +19,4 @@ COPY daemon.conf /etc/pulse/daemon.conf
 COPY 95-balena-audio.rules /etc/udev/rules.d/95-balena-audio.rules
 
 ENTRYPOINT [ "/bin/bash", "/usr/src/entry.sh" ]
-CMD [ "pulseaudio" ]
+CMD [ "pulseaudio", "--daemonize=false", "--log-target=stderr" ]


### PR DESCRIPTION
Use --log-target=stderr and --daemonize=false so errors and warnings will show up better in the logs. Note that systemd uses `--daemonize=false` when launchin the `pulseaudio.service`:

```
$ systemctl --user cat pulseaudio.service | grep ExecStart
ExecStart=/usr/bin/pulseaudio --daemonize=no
```
