### PR TITLE
rpi: use alpine base images for raspberry-pi images

### DIFF
--- a/Dockerfile.raspberry-pi
+++ b/Dockerfile.raspberry-pi
@@ -1,4 +1,5 @@
-FROM balenalib/raspberry-pi-debian:buster-run
+# Alpine 3.12 pins pulseaudio package to v13 which is what we want
+FROM balenalib/raspberry-pi-alpine:3.12
 WORKDIR /usr/src
 
 # Required to autodetect ALSA devices
@@ -7,12 +8,7 @@ ENV UDEV=on
 # DBUS is required for module-bluetooth-discover
 ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 
-# We want pulseaudio v13 which is available only in buster-backports
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC
-RUN install_packages -t buster-backports pulseaudio=13* pulseaudio-module-bluetooth=13* 
-RUN install_packages xxd alsa-utils
+RUN install_packages mawk xxd alsa-utils pulseaudio pulseaudio-alsa pulseaudio-bluez pulseaudio-utils
 
 # For local development
 #dev-cmd-live=pulseaudio || balena-idle
@@ -27,6 +23,9 @@ COPY udev/95-balena-audio.rules /etc/udev/rules.d/95-balena-audio.rules
 
 # Entrypoint
 COPY entry.sh .
+
+# Replace awk for mawk
+RUN sed -i -e 's:awk:mawk:g' /usr/src/entry.sh
 
 ENTRYPOINT [ "/bin/bash", "/usr/src/entry.sh" ]
 CMD [ "pulseaudio" ]

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -26,10 +26,10 @@ if [[ $DIRNAME != './scripts' ]]; then
   echo "Please run from project's root directory"
 fi
 
-# build_and_push_image "raspberrypi4-64" "linux/arm64"
-# build_and_push_image "raspberrypi3-64" "linux/arm64"
-# build_and_push_image "raspberrypi3" "linux/arm/v7"
-# build_and_push_image "raspberry-pi2" "linux/arm/v7"
+build_and_push_image "raspberrypi4-64" "linux/arm64"
+build_and_push_image "raspberrypi3-64" "linux/arm64"
+build_and_push_image "raspberrypi3" "linux/arm/v7"
+build_and_push_image "raspberry-pi2" "linux/arm/v7"
 build_and_push_image "raspberry-pi" "linux/arm/v6" "true"
 build_and_push_image "fincm3" "linux/arm/v7"
 build_and_push_image "intel-nuc" "linux/amd64"


### PR DESCRIPTION
Closes: #62
Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>