### PR TITLE
Bump PulseAudio to v15

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,10 +1,10 @@
 # --- Note on PulseAudio version ---
-# Alpine 3.12 pins PulseAudio version to 13.x.x
-# See https://pkgs.alpinelinux.org/packages?name=pulseaudio&branch=v3.12
+# Alpine 3.15 pins PulseAudio version to 15.x.x
+# See https://pkgs.alpinelinux.org/packages?name=pulseaudio&branch=v3.15
 
 ARG BALENA_ARCH=%%BALENA_ARCH%%
 
-FROM balenalib/$BALENA_ARCH-alpine:3.12-run
+FROM balenalib/$BALENA_ARCH-alpine:3.15-run
 WORKDIR /usr/src
 
 # UDev is required to autodetect ALSA devices
@@ -16,7 +16,7 @@ ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 RUN install_packages \
   alsa-utils \
   mawk \
-  pulseaudio~=13 \
+  pulseaudio~=15 \
   pulseaudio-alsa \
   pulseaudio-bluez \
   pulseaudio-utils \
@@ -26,7 +26,7 @@ RUN install_packages \
 #dev-cmd-live=pulseaudio || balena-idle
 
 # PulseAudio configuration
-COPY pulseaudio/block.pa /etc/pulse/block.pa
+COPY pulseaudio/block.pa /etc/pulse/default.pa.d/00-audioblock.pa
 COPY pulseaudio/client.conf /etc/pulse/client.conf
 COPY pulseaudio/daemon.conf /etc/pulse/daemon.conf
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The `audio` block is a docker image that runs a [PulseAudio](https://www.freedes
 
 ## Features
 
-- PulseAudio v13 audio server
+- PulseAudio v15 audio server
 - Configuration optimized for balenaOS, extendable via PA config files
 - Supports both TCP and UNIX socket communication
 - Bluetooth and ALSA support out of the box

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   # EXAMPLES SECTION
   # Bluetooth agent
   bluetooth:
-    build: ./examples/bluetooth
+    image: balenablocks/bluetooth
     network_mode: host
     cap_add:
       - NET_ADMIN

--- a/examples/bluetooth/Dockerfile.template
+++ b/examples/bluetooth/Dockerfile.template
@@ -1,1 +1,0 @@
-FROM balenablocks/bluetooth:%%BALENA_MACHINE_NAME%%

--- a/pulseaudio/block.pa
+++ b/pulseaudio/block.pa
@@ -1,12 +1,9 @@
-# Load default PulseAudio configuration
-.include /etc/pulse/default.pa
-
 # Load server protocols for clients
 load-module module-native-protocol-unix auth-anonymous=true auth-cookie-enabled=false auth-cookie=/run/pulse/pulseaudio.cookie socket=/run/pulse/pulseaudio.socket
 load-module module-native-protocol-tcp auth-anonymous=true auth-cookie-enabled=false auth-cookie=/run/pulse/pulseaudio.cookie port=4317
 
 # Try to keep bluetooth sources as A2DP profiles
-load-module module-bluetooth-policy a2dp_source=true hfgw=true auto_switch=2
+load-module module-bluetooth-policy a2dp_source=true auto_switch=2
 
 # See https://github.com/raspberrypi/linux/issues/2229#issuecomment-391397669
 load-module module-bluetooth-discover autodetect_mtu=yes headset=native

--- a/pulseaudio/daemon.conf
+++ b/pulseaudio/daemon.conf
@@ -17,7 +17,7 @@ realtime-scheduling = yes
 exit-idle-time = -1
 
 ; Paths
-default-script-file = /etc/pulse/block.pa
+default-script-file = /etc/pulse/default.pa
 
 ; Logging
 log-level = notice


### PR DESCRIPTION
Update PulseAudio sound server to a recent version.

Related changelogs:
- https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/14.0/
- https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/15.0/


Closes: #84, https://github.com/balenalabs/balena-sound/issues/527, https://github.com/balenalabs/balena-sound/issues/300